### PR TITLE
Fix expansion error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
-*/target
+*target
 .idea/
 *logs
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
+*hp.obo
+*.hpoa
 *target
 .idea/
 *logs

--- a/phenomiser-cli/src/main/java/org/jax/cmd/QueryCommand.java
+++ b/phenomiser-cli/src/main/java/org/jax/cmd/QueryCommand.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.Parameters;
 import org.jax.Phenomiser;
 import org.jax.io.DiseaseParser;
 import org.jax.io.HpoParser;
+import org.jax.model.Item2PValueAndSimilarity;
 import org.jax.services.AbstractResources;
 import org.jax.services.CachedResources;
 import org.jax.utils.DiseaseDB;
@@ -72,7 +73,7 @@ public class QueryCommand extends PhenomiserCommand {
 
 
         List<DiseaseDB> db = Arrays.stream(diseaseDB.split(",")).map(DiseaseDB::valueOf).collect(Collectors.toList());
-        List<Item2PValue<TermId>> result = Phenomiser.query(queryList, db);
+        List<Item2PValueAndSimilarity<TermId>> result = Phenomiser.query(queryList, db);
 
         //output query result
         if (!result.isEmpty()) {
@@ -91,7 +92,8 @@ public class QueryCommand extends PhenomiserCommand {
         return writer;
     }
 
-    public void write_query_result(List<Item2PValue<TermId>> result, @Nullable String outPath) {
+    public void write_query_result(List<Item2PValueAndSimilarity<TermId>> result, @Nullable String
+            outPath) {
 
 //        if (adjusted_p_value == null) {
 //            return;
@@ -100,12 +102,14 @@ public class QueryCommand extends PhenomiserCommand {
         Writer writer = getWriter(outPath);
 
         try {
-            writer.write("diseaseId\tdiseaseName\tp\tadjust_p\n");
+            writer.write("diseaseId\tdiseaseName\tp\tadjust_p" +
+                    "\tsimilarityScore" +
+                    "\n");
         } catch (IOException e) {
             logger.error("io exception during writing header. writing output aborted.");
             return;
         }
-        List<Item2PValue<TermId>> newList = new ArrayList<>(result);
+        List<Item2PValueAndSimilarity<TermId>> newList = new ArrayList<>(result);
         Collections.sort(newList);
 
         newList.stream().forEach(e -> {
@@ -117,6 +121,8 @@ public class QueryCommand extends PhenomiserCommand {
                 writer.write(Double.toString(e.getRawPValue()));
                 writer.write("\t");
                 writer.write(Double.toString(e.getAdjustedPValue()));
+                writer.write("\t");
+                writer.write(Double.toString(e.getSimilarityScore()));
                 writer.write("\n");
             } catch (IOException exception) {
                 logger.error("IO exception during writing out adjusted p values");

--- a/phenomiser-core/pom.xml
+++ b/phenomiser-core/pom.xml
@@ -23,4 +23,12 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>22.0</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/phenomiser-core/src/main/java/org/jax/Phenomiser.java
+++ b/phenomiser-core/src/main/java/org/jax/Phenomiser.java
@@ -46,9 +46,7 @@ public class Phenomiser {
         //estimate p values for each disease
         PValueCalculator pValueCalculator = new PValueCalculator(queryTerms.size(), similarityScores, resources);
 
-      //  Map<Integer, Double> pvals = pValueCalculator.calculatePValues();
-
-        //p value multi test correction
+        //calculate p value and multi test correction
         List<Item2PValue<TermId>> mylist = pValueCalculator.adjustPvals();
 
         return mylist;

--- a/phenomiser-core/src/main/java/org/jax/Phenomiser.java
+++ b/phenomiser-core/src/main/java/org/jax/Phenomiser.java
@@ -1,10 +1,12 @@
 package org.jax;
 
+import org.jax.model.Item2PValueAndSimilarity;
 import org.jax.services.AbstractResources;
 import org.jax.services.PValueCalculator;
 import org.jax.services.SimilarityScoreCalculator;
 import org.jax.utils.DiseaseDB;
 import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.stats.BenjaminiHochberg;
 import org.monarchinitiative.phenol.stats.Item2PValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +34,7 @@ public class Phenomiser {
      * @param queryTerms a list of HPO termIds
      * @param dbs a list of disease databases
      */
-    public static List<Item2PValue<TermId>> query(List<TermId> queryTerms, List<DiseaseDB> dbs) {
+    public static List<Item2PValueAndSimilarity<TermId>> query(List<TermId> queryTerms, List<DiseaseDB> dbs) {
 
         if (queryTerms == null || dbs == null || queryTerms.isEmpty() || dbs.isEmpty()) {
             return null;
@@ -46,10 +48,19 @@ public class Phenomiser {
         //estimate p values for each disease
         PValueCalculator pValueCalculator = new PValueCalculator(queryTerms.size(), similarityScores, resources);
 
-        //calculate p value and multi test correction
-        List<Item2PValue<TermId>> mylist = pValueCalculator.adjustPvals();
+        //No need to call this method since the following call calls it anyway
+//        Map<TermId, Item2PValueAndSimilarity<TermId>> pvalues =
+//                pValueCalculator.calculatePValues();
 
-        return mylist;
+        //multi test correction
+        //call Benjamini Hochberg method
+        List<Item2PValueAndSimilarity<TermId>> adjusted = pValueCalculator
+                .adjustPvals(new BenjaminiHochberg<>());
+
+//        //calculate p value and multi test correction
+//        List<Item2PValue<TermId>> mylist = pValueCalculator.adjustPvals();
+
+        return adjusted;
     }
 
 }

--- a/phenomiser-core/src/main/java/org/jax/grid/PhenotypeOnlyHpoCaseSimulator.java
+++ b/phenomiser-core/src/main/java/org/jax/grid/PhenotypeOnlyHpoCaseSimulator.java
@@ -5,6 +5,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.jax.Phenomiser;
 import org.jax.io.DiseaseParser;
+import org.jax.model.Item2PValueAndSimilarity;
 import org.jax.services.AbstractResources;
 import org.jax.utils.DiseaseDB;
 import org.monarchinitiative.phenol.formats.hpo.HpoAnnotation;
@@ -246,8 +247,13 @@ public class PhenotypeOnlyHpoCaseSimulator {
     public int simulateCase(HpoDisease disease) {
 
         List<TermId> randomizedTerms = getRandomTermsFromDisease(disease);
-        List<Item2PValue<TermId>> result = Phenomiser.query(randomizedTerms, this.db);
+        List<Item2PValueAndSimilarity<TermId>> result = Phenomiser.query(randomizedTerms,
+                this.db);
         //result.stream().forEach(r -> System.out.println(r.getItem().getValue()));
+        //@TODO: to allow shared ranks when pval and similarity scores are
+        // both identical. Item2PValueAndSimilarity has both value to
+        // calculate this
+
         int rank = -1;
         for (int i = 0; i < result.size(); i++) {
             if (result.get(i).getItem().equals(disease.getDiseaseDatabaseId())) {

--- a/phenomiser-core/src/main/java/org/jax/model/Item2PValueAndSimilarity.java
+++ b/phenomiser-core/src/main/java/org/jax/model/Item2PValueAndSimilarity.java
@@ -1,0 +1,55 @@
+package org.jax.model;
+
+import com.google.common.math.DoubleMath;
+import org.monarchinitiative.phenol.stats.Item2PValue;
+
+public class Item2PValueAndSimilarity<T> extends Item2PValue<T> {
+
+    private double similarityScore;
+
+    /**
+     * This constructor takes an Item for which a pvalue was calculated. It assigned both {@link #p_raw} (the
+     * raw pavel) and {@link #p_adjusted} to this value (i.e., by default there is no multiple testing
+     * correction. The class is designed to be used with other classes such as {@link Bonferroni} to
+     * adjust the raw pvalues that are stored in {@link #p_adjusted}.
+     *
+     * @param item
+     * @param p
+     */
+    public Item2PValueAndSimilarity(T item, double p) {
+        super(item, p);
+    }
+
+    public Item2PValueAndSimilarity(T item, double p, double
+            similarityScore) {
+        super(item, p);
+        this.similarityScore = similarityScore;
+    }
+
+    public Item2PValueAndSimilarity(Item2PValue<T> item2PValue) {
+        super(item2PValue.getItem(), item2PValue.getRawPValue());
+    }
+
+    public double getSimilarityScore() {
+        return similarityScore;
+    }
+
+    public void setSimilarityScore(double similarityScore) {
+        this.similarityScore = similarityScore;
+    }
+
+    @Override
+    public int compareTo(Item2PValue o) {
+        Item2PValueAndSimilarity other = (Item2PValueAndSimilarity) o;
+        final double DELTA = 0.0001;
+
+        if (this.getRawPValue() == o.getRawPValue()) {
+            return DoubleMath.fuzzyCompare(this.similarityScore, other
+                    .similarityScore, DELTA);
+        } else {
+            return DoubleMath.fuzzyCompare(this.getRawPValue(), other.getRawPValue(),
+                    DELTA);
+        }
+    }
+
+}

--- a/phenomiser-core/src/main/java/org/jax/model/SearchResult.java
+++ b/phenomiser-core/src/main/java/org/jax/model/SearchResult.java
@@ -1,7 +1,8 @@
-package org.jax.services;
+package org.jax.model;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
+@Deprecated
 public class SearchResult implements Comparable<SearchResult> {
     private final TermId tid;
     private final double pval;

--- a/phenomiser-core/src/main/java/org/jax/services/AbstractResources.java
+++ b/phenomiser-core/src/main/java/org/jax/services/AbstractResources.java
@@ -27,9 +27,11 @@ public abstract class AbstractResources {
 
     protected Map<TermId, HpoDisease> diseaseMap;
 
-    protected Map<TermId, Collection<TermId>> diseaseIdToHpoTermIds;
+    protected Map<TermId, Collection<TermId>> diseaseIdToHpoTermIdsWithExpansion;
+    protected Map<TermId, Collection<TermId>> diseaseIdToHpoTermIdsNoExpansion;
 
-    protected Map<TermId, Collection<TermId>> hpoTermIdToDiseaseIds;
+    protected Map<TermId, Collection<TermId>> hpoTermIdToDiseaseIdsWithExpansion;
+    protected Map<TermId, Collection<TermId>> hpoTermIdToDiseaseIdsNoExpansion;
 
     protected Map<TermId, Double> icMap;
 
@@ -37,11 +39,14 @@ public abstract class AbstractResources {
 
     protected ResnikSimilarity resnikSimilarity;
 
-    protected Map<Integer, List<TermId>> diseaseIndexToHpoTerms;
+    protected Map<Integer, List<TermId>> diseaseIndexToHpoTermsWithExpansion;
+    protected Map<Integer, List<TermId>> diseaseIndexToHpoTermsNoExpansion;
 
     protected Map<Integer, TermId> diseaseIndexToDisease;
 
     protected Map<Integer, ScoreDistribution> scoreDistributions;
+
+
 
     public AbstractResources(HpoParser hpoParser, DiseaseParser diseaseParser) {
         this.hpoParser = hpoParser;
@@ -69,10 +74,16 @@ public abstract class AbstractResources {
 
         logger.trace("disease map initiation started");
         diseaseMap = this.diseaseParser.getDiseaseMap();
-        diseaseIdToHpoTermIds = this.diseaseParser.getDiseaseIdToHpoTermIds();
-        hpoTermIdToDiseaseIds = this.diseaseParser.getHpoTermIdToDiseaseIds();
+        diseaseIdToHpoTermIdsWithExpansion = this.diseaseParser.getDiseaseIdToHpoTermIdsWithExpansion();
+        diseaseIdToHpoTermIdsNoExpansion = this.diseaseParser
+                .getDiseaseIdToHpoTermIdsNoExpansion();
+        hpoTermIdToDiseaseIdsWithExpansion = this.diseaseParser.getHpoTermIdToDiseaseIdsWithExpansion();
+        hpoTermIdToDiseaseIdsNoExpansion = this.diseaseParser
+                .getHpoTermIdToDiseaseIdsNoExpansion();
         diseaseIndexToDisease = this.diseaseParser.getDiseaseIndexToDisease();
-        diseaseIndexToHpoTerms = this.diseaseParser.getDiseaseIndexToHpoTerms();
+        diseaseIndexToHpoTermsWithExpansion = this.diseaseParser.getDiseaseIndexToHpoTermsWithExpansion();
+        diseaseIndexToHpoTermsNoExpansion = this.diseaseParser
+                .getDiseaseIndexToHpoTermsNoExpansion();
         logger.trace("disease map initiation success");
 
     }
@@ -111,20 +122,20 @@ public abstract class AbstractResources {
         this.diseaseMap = diseaseMap;
     }
 
-    public Map<TermId, Collection<TermId>> getDiseaseIdToHpoTermIds() {
-        return diseaseIdToHpoTermIds;
+    public Map<TermId, Collection<TermId>> getDiseaseIdToHpoTermIdsWithExpansion() {
+        return diseaseIdToHpoTermIdsWithExpansion;
     }
 
-    public void setDiseaseIdToHpoTermIds(Map<TermId, Collection<TermId>> diseaseIdToHpoTermIds) {
-        this.diseaseIdToHpoTermIds = diseaseIdToHpoTermIds;
+    public void setDiseaseIdToHpoTermIdsWithExpansion(Map<TermId, Collection<TermId>> diseaseIdToHpoTermIdsWithExpansion) {
+        this.diseaseIdToHpoTermIdsWithExpansion = diseaseIdToHpoTermIdsWithExpansion;
     }
 
-    public Map<TermId, Collection<TermId>> getHpoTermIdToDiseaseIds() {
-        return hpoTermIdToDiseaseIds;
+    public Map<TermId, Collection<TermId>> getHpoTermIdToDiseaseIdsWithExpansion() {
+        return hpoTermIdToDiseaseIdsWithExpansion;
     }
 
-    public void setHpoTermIdToDiseaseIds(Map<TermId, Collection<TermId>> hpoTermIdToDiseaseIds) {
-        this.hpoTermIdToDiseaseIds = hpoTermIdToDiseaseIds;
+    public void setHpoTermIdToDiseaseIdsWithExpansion(Map<TermId, Collection<TermId>> hpoTermIdToDiseaseIdsWithExpansion) {
+        this.hpoTermIdToDiseaseIdsWithExpansion = hpoTermIdToDiseaseIdsWithExpansion;
     }
 
     public Map<TermId, Double> getIcMap() {
@@ -151,12 +162,12 @@ public abstract class AbstractResources {
         this.resnikSimilarity = resnikSimilarity;
     }
 
-    public Map<Integer, List<TermId>> getDiseaseIndexToHpoTerms() {
-        return diseaseIndexToHpoTerms;
+    public Map<Integer, List<TermId>> getDiseaseIndexToHpoTermsWithExpansion() {
+        return diseaseIndexToHpoTermsWithExpansion;
     }
 
-    public void setDiseaseIndexToHpoTerms(Map<Integer, List<TermId>> diseaseIndexToHpoTerms) {
-        this.diseaseIndexToHpoTerms = diseaseIndexToHpoTerms;
+    public void setDiseaseIndexToHpoTermsWithExpansion(Map<Integer, List<TermId>> diseaseIndexToHpoTermsWithExpansion) {
+        this.diseaseIndexToHpoTermsWithExpansion = diseaseIndexToHpoTermsWithExpansion;
     }
 
     public Map<Integer, TermId> getDiseaseIndexToDisease() {
@@ -173,5 +184,29 @@ public abstract class AbstractResources {
 
     public void setScoreDistributions(Map<Integer, ScoreDistribution> scoreDistributions) {
         this.scoreDistributions = scoreDistributions;
+    }
+
+    public Map<TermId, Collection<TermId>> getDiseaseIdToHpoTermIdsNoExpansion() {
+        return diseaseIdToHpoTermIdsNoExpansion;
+    }
+
+    public void setDiseaseIdToHpoTermIdsNoExpansion(Map<TermId, Collection<TermId>> diseaseIdToHpoTermIdsNoExpansion) {
+        this.diseaseIdToHpoTermIdsNoExpansion = diseaseIdToHpoTermIdsNoExpansion;
+    }
+
+    public Map<TermId, Collection<TermId>> getHpoTermIdToDiseaseIdsNoExpansion() {
+        return hpoTermIdToDiseaseIdsNoExpansion;
+    }
+
+    public void setHpoTermIdToDiseaseIdsNoExpansion(Map<TermId, Collection<TermId>> hpoTermIdToDiseaseIdsNoExpansion) {
+        this.hpoTermIdToDiseaseIdsNoExpansion = hpoTermIdToDiseaseIdsNoExpansion;
+    }
+
+    public Map<Integer, List<TermId>> getDiseaseIndexToHpoTermsNoExpansion() {
+        return diseaseIndexToHpoTermsNoExpansion;
+    }
+
+    public void setDiseaseIndexToHpoTermsNoExpansion(Map<Integer, List<TermId>> diseaseIndexToHpoTermsNoExpansion) {
+        this.diseaseIndexToHpoTermsNoExpansion = diseaseIndexToHpoTermsNoExpansion;
     }
 }

--- a/phenomiser-core/src/main/java/org/jax/services/CachedResources.java
+++ b/phenomiser-core/src/main/java/org/jax/services/CachedResources.java
@@ -60,7 +60,7 @@ public class CachedResources extends AbstractResources{
             logger.trace("deserialize information content map failed");
             logger.error("file not found" + icMapPath);
             logger.trace("information content map initiation started");
-            icMap = new InformationContentComputation(hpo).computeInformationContent(hpoTermIdToDiseaseIds);
+            icMap = new InformationContentComputation(hpo).computeInformationContent(hpoTermIdToDiseaseIdsWithExpansion);
             logger.trace("information content map initiation success");
         } catch (IOException e) {
             logger.trace("deserialize information content map failed");

--- a/phenomiser-core/src/main/java/org/jax/services/ComputedResources.java
+++ b/phenomiser-core/src/main/java/org/jax/services/ComputedResources.java
@@ -96,7 +96,7 @@ public class ComputedResources extends AbstractResources {
 
         //init icMap
         logger.trace("information content map initiation started");
-        icMap = new InformationContentComputation(hpo).computeInformationContent(hpoTermIdToDiseaseIds);
+        icMap = new InformationContentComputation(hpo).computeInformationContent(hpoTermIdToDiseaseIdsWithExpansion);
         logger.trace("information content map initiation success");
 
         //init Resnik similarity precomputation
@@ -123,7 +123,8 @@ public class ComputedResources extends AbstractResources {
         SimilarityScoreSampling sampleing;//
         if (this.debug) {
             sampleing = new SimilarityScoreSampling(hpo, resnikSimilarity, samplingOption);
-            Map<Integer, List<TermId>> subset = diseaseIndexToHpoTerms.entrySet().stream()
+            Map<Integer, List<TermId>> subset =
+                    diseaseIndexToHpoTermsNoExpansion.entrySet().stream()
                     .limit(50).collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
             scoreDistributions.putAll(sampleing.performSampling(subset));
         } else {
@@ -133,7 +134,8 @@ public class ComputedResources extends AbstractResources {
                 newoption.setMinNumTerms(i);
                 newoption.setMaxNumTerms(i);
                 sampleing = new SimilarityScoreSampling(hpo, resnikSimilarity, newoption);
-                scoreDistributions.putAll(sampleing.performSampling(diseaseIndexToHpoTerms));
+                scoreDistributions.putAll(sampleing.performSampling
+                        (diseaseIndexToHpoTermsNoExpansion));
             }
         }
 

--- a/phenomiser-core/src/main/java/org/jax/services/SimilarityScoreCalculator.java
+++ b/phenomiser-core/src/main/java/org/jax/services/SimilarityScoreCalculator.java
@@ -1,5 +1,6 @@
 package org.jax.services;
 
+import org.jax.model.SearchResult;
 import org.jax.utils.DiseaseDB;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -17,61 +18,42 @@ public class SimilarityScoreCalculator {
         this.resources = resources;
     }
 
+    @Deprecated
     public Map<Integer, Double> compute(List<TermId> query, List<DiseaseDB> dbs) {
 
         String filter = dbs.stream().map(DiseaseDB::name).reduce((a, b) -> a + "|" + b).get();
 
         Map<Integer, Double> similarityScores = new HashMap<>();
-        Map<Integer, Double> sortedSimilarityScores = new HashMap<>();
 
         resources.getDiseaseIndexToHpoTermsNoExpansion().entrySet().stream()
                 .filter(e -> resources.getDiseaseIndexToDisease().get(e.getKey()).getPrefix().matches(filter))
                 .forEach(e -> similarityScores.put(e.getKey(),
                         resources.getResnikSimilarity().computeScore(query, e.getValue())));
-/*
-       for (Map.Entry<Integer,List<TermId>> mentry : resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet()) {
-           if (resources.getDiseaseIndexToDisease().get(mentry.getKey()).getPrefix().matches(filter) ) {
-               TermId diseaseId = resources.getDiseaseIndexToDisease().get(mentry.getKey());
-               double sim = resources.getResnikSimilarity().computeScore(query, mentry.getValue());
-//               if (diseaseId.getValue().equals("OMIM:612642")) {
-//                   System.err.println("OMIM:612642 sim="+sim );
-//               }
-           }
-        }
-        sortedSimilarityScores = similarityScores
-                .entrySet()
-                .stream()
-                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
-                .collect(
-                        toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2,
-                                LinkedHashMap::new));
-
-        System.out.println("map after sorting by values in descending order: "
-                + sortedSimilarityScores);
-
-        System.out.println("map before sorting: "
-                + similarityScores);
-
-//        List<TermId> diseases=resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet().stream()
-//                .filter(e -> resources.getDiseaseIndexToDisease().get(e.getKey()).getPrefix().matches(filter)).collect(Collectors.toList());
-*/
-
-        int QUERY_COUNT=5;
-
-        int N = similarityScores.size();
-        for (Integer i : similarityScores.keySet()) {
-            TermId diseaseId = resources.getDiseaseIndexToDisease().get(i);
-            double semsim = similarityScores.get(i);
-            double p =  resources.scoreDistributions.get(QUERY_COUNT).getObjectScoreDistribution(i).estimatePValue(semsim);
-            double pval_adj = Math.max(1.0,N*p); // Bonferroni
-            SearchResult sresult = new SearchResult(diseaseId,pval_adj,semsim);
-        }
-
-
 
         return similarityScores;
     }
 
+    /**
+     * This is preferred over above method
+     * @TODO: refactor PValueCalculator to use this method
+     * @param query
+     * @param dbs
+     * @return
+     */
+    public Map<TermId, Double> computeB(List<TermId> query, List<DiseaseDB>
+            dbs) {
+
+        String filter = dbs.stream().map(DiseaseDB::name).reduce((a, b) -> a + "|" + b).get();
+
+        Map<TermId, Double> similarityScores = new HashMap<>();
+
+        resources.getDiseaseIdToHpoTermIdsNoExpansion().entrySet().stream()
+                .filter(e -> e.getKey().getPrefix().matches(filter))
+                .forEach(e -> similarityScores.put(e.getKey(),
+                        resources.getResnikSimilarity().computeScore(query, e.getValue())));
+
+        return similarityScores;
+    }
 
     public List<SearchResult> compute2(List<TermId> query, List<DiseaseDB> dbs) {
 

--- a/phenomiser-core/src/main/java/org/jax/services/SimilarityScoreCalculator.java
+++ b/phenomiser-core/src/main/java/org/jax/services/SimilarityScoreCalculator.java
@@ -24,12 +24,12 @@ public class SimilarityScoreCalculator {
         Map<Integer, Double> similarityScores = new HashMap<>();
         Map<Integer, Double> sortedSimilarityScores = new HashMap<>();
 
-        resources.getDiseaseIndexToHpoTerms().entrySet().stream()
+        resources.getDiseaseIndexToHpoTermsNoExpansion().entrySet().stream()
                 .filter(e -> resources.getDiseaseIndexToDisease().get(e.getKey()).getPrefix().matches(filter))
                 .forEach(e -> similarityScores.put(e.getKey(),
                         resources.getResnikSimilarity().computeScore(query, e.getValue())));
 /*
-       for (Map.Entry<Integer,List<TermId>> mentry : resources.getDiseaseIndexToHpoTerms().entrySet()) {
+       for (Map.Entry<Integer,List<TermId>> mentry : resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet()) {
            if (resources.getDiseaseIndexToDisease().get(mentry.getKey()).getPrefix().matches(filter) ) {
                TermId diseaseId = resources.getDiseaseIndexToDisease().get(mentry.getKey());
                double sim = resources.getResnikSimilarity().computeScore(query, mentry.getValue());
@@ -52,7 +52,7 @@ public class SimilarityScoreCalculator {
         System.out.println("map before sorting: "
                 + similarityScores);
 
-//        List<TermId> diseases=resources.getDiseaseIndexToHpoTerms().entrySet().stream()
+//        List<TermId> diseases=resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet().stream()
 //                .filter(e -> resources.getDiseaseIndexToDisease().get(e.getKey()).getPrefix().matches(filter)).collect(Collectors.toList());
 */
 
@@ -80,12 +80,12 @@ public class SimilarityScoreCalculator {
         Map<Integer, Double> similarityScores = new HashMap<>();
         Map<Integer, Double> sortedSimilarityScores = new HashMap<>();
 
-        resources.getDiseaseIndexToHpoTerms().entrySet().stream()
+        resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet().stream()
                 .filter(e -> resources.getDiseaseIndexToDisease().get(e.getKey()).getPrefix().matches(filter))
                 .forEach(e -> similarityScores.put(e.getKey(),
                         resources.getResnikSimilarity().computeScore(query, e.getValue())));
 /*
-       for (Map.Entry<Integer,List<TermId>> mentry : resources.getDiseaseIndexToHpoTerms().entrySet()) {
+       for (Map.Entry<Integer,List<TermId>> mentry : resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet()) {
            if (resources.getDiseaseIndexToDisease().get(mentry.getKey()).getPrefix().matches(filter) ) {
                TermId diseaseId = resources.getDiseaseIndexToDisease().get(mentry.getKey());
                double sim = resources.getResnikSimilarity().computeScore(query, mentry.getValue());
@@ -108,7 +108,7 @@ public class SimilarityScoreCalculator {
         System.out.println("map before sorting: "
                 + similarityScores);
 
-//        List<TermId> diseases=resources.getDiseaseIndexToHpoTerms().entrySet().stream()
+//        List<TermId> diseases=resources.getDiseaseIndexToHpoTermsWithExpansion().entrySet().stream()
 //                .filter(e -> resources.getDiseaseIndexToDisease().get(e.getKey()).getPrefix().matches(filter)).collect(Collectors.toList());
 */
 

--- a/phenomiser-core/src/test/java/org/jax/io/DiseaseParserTest.java
+++ b/phenomiser-core/src/test/java/org/jax/io/DiseaseParserTest.java
@@ -80,16 +80,16 @@ public class DiseaseParserTest {
 
     @Test
     public void getDiseaseIdToHpoTermIds() throws Exception {
-        assertNotNull(diseaseParser.getDiseaseIdToHpoTermIds());
-        assertTrue(! diseaseParser.getDiseaseIdToHpoTermIds().isEmpty());
-        assertEquals(diseaseParser.getDiseaseIdToHpoTermIds().size(), 2);
+        assertNotNull(diseaseParser.getDiseaseIdToHpoTermIdsWithExpansion());
+        assertTrue(! diseaseParser.getDiseaseIdToHpoTermIdsWithExpansion().isEmpty());
+        assertEquals(diseaseParser.getDiseaseIdToHpoTermIdsWithExpansion().size(), 2);
     }
 
     @Test
     public void getHpoTermIdToDiseaseIds() throws Exception {
-        assertNotNull(diseaseParser.getHpoTermIdToDiseaseIds());
-        assertTrue(! diseaseParser.getHpoTermIdToDiseaseIds().isEmpty());
-        assertEquals(diseaseParser.getHpoTermIdToDiseaseIds().size(), 2);
+        assertNotNull(diseaseParser.getHpoTermIdToDiseaseIdsWithExpansion());
+        assertTrue(! diseaseParser.getHpoTermIdToDiseaseIdsWithExpansion().isEmpty());
+        assertEquals(diseaseParser.getHpoTermIdToDiseaseIdsWithExpansion().size(), 2);
     }
 
     @Test
@@ -101,9 +101,9 @@ public class DiseaseParserTest {
 
     @Test
     public void getDiseaseIndexToHpoTerm() throws Exception {
-        assertNotNull(diseaseParser.getDiseaseIndexToHpoTerms());
-        assertTrue(! diseaseParser.getDiseaseIndexToHpoTerms().isEmpty());
-        assertEquals(diseaseParser.getDiseaseIndexToHpoTerms().size(), 2);
+        assertNotNull(diseaseParser.getDiseaseIndexToHpoTermsWithExpansion());
+        assertTrue(! diseaseParser.getDiseaseIndexToHpoTermsWithExpansion().isEmpty());
+        assertEquals(diseaseParser.getDiseaseIndexToHpoTermsWithExpansion().size(), 2);
     }
 
 }

--- a/phenomiser-core/src/test/java/org/jax/services/ComputedResourcesTest.java
+++ b/phenomiser-core/src/test/java/org/jax/services/ComputedResourcesTest.java
@@ -64,7 +64,7 @@ public class ComputedResourcesTest {
 
     @Test
     public void getNoAnnotationDiseases() {
-        Set<TermId> noAnnotationDiseases = resources.getDiseaseIdToHpoTermIds().entrySet().stream().filter(e -> e.getValue().size() == 0).map(e -> e.getKey()).collect(Collectors.toSet());
+        Set<TermId> noAnnotationDiseases = resources.getDiseaseIdToHpoTermIdsWithExpansion().entrySet().stream().filter(e -> e.getValue().size() == 0).map(e -> e.getKey()).collect(Collectors.toSet());
         //System.out.println(noAnnotationDiseases.size());
         noAnnotationDiseases.forEach(t -> System.out.println(t.getValue()));
     }

--- a/phenomiser-core/src/test/java/org/jax/services/PValueCalculatorTest.java
+++ b/phenomiser-core/src/test/java/org/jax/services/PValueCalculatorTest.java
@@ -75,7 +75,7 @@ import static org.junit.Assert.*;
 //
 //    @Test
 //    public void calculatePValues() throws Exception {
-////        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIds().keySet().stream().limit(3).collect(Collectors.toList());
+////        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIdsWithExpansion().keySet().stream().limit(3).collect(Collectors.toList());
 ////        Map<Integer, Double> scores = similarityScoreCalculator.compute(randomTermList, Arrays.asList(DiseaseDB.OMIM, DiseaseDB.ORPHA));
 ////        pvalueCalculation = new PValueCalculator(3, scores, resources);
 ////        pvalues = pvalueCalculation.calculatePValues();
@@ -120,7 +120,7 @@ import static org.junit.Assert.*;
 //    @Test
 //    @Ignore
 //    public void adjustPValues() {
-//        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIds().keySet().stream().limit(3).collect(Collectors.toList());
+//        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIdsWithExpansion().keySet().stream().limit(3).collect(Collectors.toList());
 //        Map<Integer, Double> scores = similarityScoreCalculator.compute(randomTermList, Arrays.asList(DiseaseDB.OMIM, DiseaseDB.ORPHA));
 //        pvalueCalculation = new PValueCalculator(3, scores, resources);
 //        BenjaminiHochberg benjaminiHochberg = new BenjaminiHochberg();
@@ -162,7 +162,7 @@ public class PValueCalculatorTest {
 //
 //    @Test
 //    public void calculatePValues() throws Exception {
-//        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIds().keySet().stream().limit(3).collect(Collectors.toList());
+//        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIdsWithExpansion().keySet().stream().limit(3).collect(Collectors.toList());
 //        Map<Integer, Double> scores = similarityScoreCalculator.compute(randomTermList, Arrays.asList(DiseaseDB.OMIM, DiseaseDB.ORPHA));
 //        pvalueCalculation = new PValueCalculator(3, scores, resources);
 //        pvalues = pvalueCalculation.calculatePValues();
@@ -174,7 +174,7 @@ public class PValueCalculatorTest {
 //
 //    @Test
 //    public void adjustPValues() {
-//        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIds().keySet().stream().limit(3).collect(Collectors.toList());
+//        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIdsWithExpansion().keySet().stream().limit(3).collect(Collectors.toList());
 //        Map<Integer, Double> scores = similarityScoreCalculator.compute(randomTermList, Arrays.asList(DiseaseDB.OMIM, DiseaseDB.ORPHA));
 //        pvalueCalculation = new PValueCalculator(3, scores, resources);
 //        BenjaminiHochberg benjaminiHochberg = new BenjaminiHochberg();

--- a/phenomiser-core/src/test/java/org/jax/services/SearchResultTest.java
+++ b/phenomiser-core/src/test/java/org/jax/services/SearchResultTest.java
@@ -1,5 +1,6 @@
 package org.jax.services;
 
+import org.jax.model.SearchResult;
 import org.junit.Test;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 

--- a/phenomiser-core/src/test/java/org/jax/services/SimilarityScoreCalculatorTest.java
+++ b/phenomiser-core/src/test/java/org/jax/services/SimilarityScoreCalculatorTest.java
@@ -41,7 +41,7 @@ public class SimilarityScoreCalculatorTest {
 
     @Test
     public void compute() throws Exception {
-        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIds().keySet().stream().limit(3).collect(Collectors.toList());
+        List<TermId> randomTermList = resources.getHpoTermIdToDiseaseIdsWithExpansion().keySet().stream().limit(3).collect(Collectors.toList());
         Map<Integer, Double> scores = similarityScoreCalculator.compute(randomTermList, Arrays.asList(DiseaseDB.OMIM, DiseaseDB.ORPHA));
         System.out.println(scores.size());
         //scores.entrySet().stream().forEach(e -> System.out.println(e.getKey() + "\t" + e.getValue()));


### PR DESCRIPTION
I am trying to fix unnecessary parent expansion. 
Also proposed a new class for calculating rank -> Item2PValueAndSimilarity to replace SearchResult so that we can reuse the multiple test correction codes in phenol. Otherwise, we will have to re-invent the codes. 

A patch for phenol is required: https://github.com/monarch-initiative/phenol/pull/200

I have not tried to fix calculating rank (https://github.com/TheJacksonLaboratory/Phenomiser/issues/21) since you are also working on this. We can adapt your code together.

Please help review when you have time. @vidarmehr 